### PR TITLE
[DP-612] Schema 기반 permission 동작 가능하도록 수정

### DIFF
--- a/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
+++ b/superset/assets/src/SqlLab/components/ExploreResultsButton.jsx
@@ -131,7 +131,7 @@ class ExploreResultsButton extends React.PureComponent {
           metrics: [],
           groupby: [],
           viz_type: 'table',
-          since: '100 years ago',
+          since: '1 weeks ago',
           all_columns: columns.map(c => c.name),
           row_limit: 1000,
         };

--- a/superset/db_engine_specs/sparksql.py
+++ b/superset/db_engine_specs/sparksql.py
@@ -1,0 +1,25 @@
+from superset.db_engine_specs.hive import HiveEngineSpec
+from typing import List, Set, Tuple
+
+
+class SparkSqlEngineSpec(HiveEngineSpec):
+    engine = "sparksql"
+
+    _time_grain_functions = {
+        None: "{col}",
+        "PT1S": "date_trunc('second', {col})",
+        "PT1M": "date_trunc('minute', {col})",
+        "PT1H": "date_trunc('hour', {col})",
+        "P1D": "date_trunc('day', {col})",
+        "P1W": "date_trunc('week', {col})",
+        "P1M": "date_trunc('month', {col})",
+        "P0.25Y": "date_trunc('quarter', {col})",
+        "P1Y": "date_trunc('year', {col})",
+    }
+
+    # Do not expand data.. for some reason nested type from PyHive is not compatible with Presto engine spec.
+    @classmethod
+    def expand_data(
+        cls, columns: List[dict], data: List[dict]
+    ) -> Tuple[List[dict], List[dict], List[dict]]:
+        return columns, data, []


### PR DESCRIPTION
각 개발사별 접근을 위해 schema 기반 permission을 수행할 수 있도록 코드 수정 및 기타 사항을 수정

* spark sql dialect에 대응하기 위해 spark sql engine spec을 작성
  * Time grain 옵션을 사용하기 위해 (기본적으로 time grain옵션은 각 engine spec에서 정의하므로) 별도 egine spec을 정의할 필요가 있음
  * hive engine spec의 경우 Presto engine spec을 overriding하는데, 이 때 expand data가 thrift-server의 nested data type에 맞지 않아 이를 방지가히 위해 `expand_data` 항목을 재정의

* front end code 수정
  * 기본적으로 sql lab에서 쿼리한 데이터를 바탕으로 시각화를 할 때 기본 time range를 `100 years ago`로 지정하고 있는데, 임시적으로 이를 `1 weeks ago`로 수정.
  * 근본적으로는 이를 configurable하게 만들어야 하겠으나, 이는 코드 전반의 수정을 필요로 하므로 임시로 수정

* schema 기반의 permission 정책을 활용 가능하도록 코드 수정
* schema perm을 사용할 수 있도록 PR이 이미 올라와 있으나 이것 만으로는 충분하지 않아 추가적인 수정 추가
  * `get_schema_name` 의 동작이 일관적이지 않음 => sql alchemy에서 파싱한 쿼리는 schema name에 backticks (`)가 포함되어있으나 sql editor등에서 schema를 조회할 때에는 backtick이 포함되어있지 않음. 따라서 backtick으로 포함된 schema name을 받을 경우 이를 벗겨내도록 코드 수정
  * 각 model의 schema_perm 필드는 sqlalchemy의 `after_insert` hook이 호출될 때 설정하지만, 이 때는 foreign key에 해당되는 relationship 정보를 가지고 있지 않으므로 (commit 이전) 명시적으로 db 정보를 불러오도록 변경. 이 조치를 추가하지 않으면 schema_perm 필드가 [None].[some table name] 으로 저장되어 permission이 제대로 동작하지 않음
![image](https://user-images.githubusercontent.com/55680952/68572246-46f99500-04a8-11ea-9a8d-aed5c99d7fa7.png)
