### PR TITLE
[DP-924] Chart 및 Dashboard에서 CSV Export 할 때 인코딩이 제대로 적용되지 않던 부분 수정

### DIFF
--- a/superset/viz.py
+++ b/superset/viz.py
@@ -491,7 +491,9 @@ class BaseViz(object):
     def get_csv(self):
         df = self.get_df()
         include_index = not isinstance(df.index, pd.RangeIndex)
-        return df.to_csv(index=include_index, **config.get("CSV_EXPORT"))
+        csv = df.to_csv(index=include_index, **config.get("CSV_EXPORT"))
+        csv_encoded = csv.encode(config["CSV_EXPORT"].get("encoding", "utf-8"))
+        return csv_encoded
 
     def get_data(self, df):
         return df.to_dict(orient="records")


### PR DESCRIPTION
#2 와 동일한 이슈로 수정. sql lab에서의 CSV Export 하는 함수와 그 외 부분 (차트 및 대시보드) 에서 CSV Export를 수행하는 함수가 달라 누락되어 차트 및 대시보드에서는 한글 csv가 엑셀에서 깨져서 보였던 이슈가 있었음

필수 리뷰어: @wflyer 